### PR TITLE
feature: dynamically set laravel-ripple version in CI workflows

### DIFF
--- a/.github/workflows/octane.yml
+++ b/.github/workflows/octane.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - feature/*
   pull_request:
     branches:
       - main
@@ -38,6 +39,7 @@ jobs:
       # 安装 Composer 依赖
       - name: Install Laravel
         run: |
+          echo "GitHub Ref: ${{ github.ref }}"
           composer install
           composer create-project --prefer-dist laravel/laravel app "^11.0"
 
@@ -46,7 +48,9 @@ jobs:
         working-directory: app
         run: |
           composer config repositories.local-plugin path ../
-          composer require cloudtay/laravel-ripple:dev-main
+          composer clear-cache
+          composer config minimum-stability dev
+          composer require cloudtay/laravel-ripple:dev-${{ github.sha }}
           composer require laravel/octane
 
       # 初始化测试路由

--- a/.github/workflows/octane.yml
+++ b/.github/workflows/octane.yml
@@ -5,10 +5,10 @@ on:
   push:
     branches:
       - main
-      - feature/*
   pull_request:
     branches:
       - main
+      - feature/*
 
 jobs:
   test-unix:
@@ -47,12 +47,16 @@ jobs:
       - name: Initialize ripple
         working-directory: app
         run: |
+          echo "PR_BRANCH_NAME: $PR_BRANCH_NAME"
+          if [ "$PR_BRANCH_NAME" = "main" ]; then
+            VERSION="dev-main"
+          else
+            VERSION="dev-${{ github.sha }}"
+          fi
           composer config repositories.local-plugin path ../
           composer clear-cache
           composer config minimum-stability dev
-          composer require cloudtay/laravel-ripple:dev-${{ github.sha }}
-          composer require laravel/octane
-
+          composer require cloudtay/laravel-ripple:$VERSION
       # 初始化测试路由
       - name: Initialize Test Route
         working-directory: app

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - feature/*
   pull_request:
     branches:
       - main
@@ -46,8 +47,9 @@ jobs:
         working-directory: app
         run: |
           composer config repositories.local-plugin path ../
-          composer require cloudtay/laravel-ripple:dev-main
-
+          composer clear-cache
+          composer config minimum-stability dev
+          composer require cloudtay/laravel-ripple:dev-${{ github.sha }}
       # 初始化测试路由
       - name: Initialize Test Route
         working-directory: app

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -5,10 +5,10 @@ on:
   push:
     branches:
       - main
-      - feature/*
   pull_request:
     branches:
       - main
+      - feature/*
 
 jobs:
   test-unix:
@@ -46,10 +46,16 @@ jobs:
       - name: Initialize ripple
         working-directory: app
         run: |
+          echo "PR_BRANCH_NAME: $PR_BRANCH_NAME"
+          if [ "$PR_BRANCH_NAME" = "main" ]; then
+            VERSION="dev-main"
+          else
+            VERSION="dev-${{ github.sha }}"
+          fi
           composer config repositories.local-plugin path ../
           composer clear-cache
           composer config minimum-stability dev
-          composer require cloudtay/laravel-ripple:dev-${{ github.sha }}
+          composer require cloudtay/laravel-ripple:$VERSION
       # 初始化测试路由
       - name: Initialize Test Route
         working-directory: app


### PR DESCRIPTION
This commit modifies the GitHub Actions workflows for unix and octane tests to dynamically determine the version of `cloudtay/laravel-ripple` to install.

- For the `main` branch, the version is set to `dev-main`.
- For all other branches, the version is set to `dev-${{ github.sha }}`, using the commit SHA as the version identifier.

This change ensures that the CI workflows install the appropriate version of the local `laravel-ripple` package based on the current branch or commit being tested.