### PR TITLE
Analyze project startup process nesting with ripple

### DIFF
--- a/src/Config/ripple.php
+++ b/src/Config/ripple.php
@@ -24,5 +24,10 @@ return [
         \base_path('/routes'),
         \base_path('/resources'),
         \base_path('/.env')
+    ],
+    'PROCESS_NAMES' => [
+        'MONITOR'  => Env::get('RIP_PROCESS_NAME_MONITOR', 'laravel-ware'),
+        'VIRTUAL'  => Env::get('RIP_PROCESS_NAME_VIRTUAL', 'laravel-virtual'),
+        'HTTP_WORKER' => Env::get('RIP_PROCESS_NAME_HTTP_WORKER', 'laravel-worker.http'),
     ]
 ];

--- a/src/Config/ripple.php
+++ b/src/Config/ripple.php
@@ -29,5 +29,6 @@ return [
         'MONITOR'  => Env::get('RIP_PROCESS_NAME_MONITOR', 'laravel-ware'),
         'VIRTUAL'  => Env::get('RIP_PROCESS_NAME_VIRTUAL', 'laravel-virtual'),
         'HTTP_WORKER' => Env::get('RIP_PROCESS_NAME_HTTP_WORKER', 'laravel-worker.http'),
+        'SERVER_BIN' => Env::get('RIP_PROCESS_NAME_SERVER_BIN', 'laravel-ripple-server'),
     ]
 ];

--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -98,7 +98,8 @@ class HttpWorker extends Worker
      */
     public function boot(): void
     {
-        cli_set_process_title('laravel-worker.http');
+        $processName = $this->application->make('config')->get('ripple.PROCESS_NAMES.HTTP_WORKER', 'laravel-worker.http');
+        cli_set_process_title($processName);
         $this->application->singleton('rippleHttpWorker', fn () => $this);
         $this->application->singleton('httpWorker', fn () => $this);
         $this->application->singleton(HttpWorker::class, fn () => $this);

--- a/src/Inspector/Client.php
+++ b/src/Inspector/Client.php
@@ -236,7 +236,7 @@ class Client
             Output::warning('Failed to register signal handler');
         }
 
-        cli_set_process_title('laravel-ware');
+        cli_set_process_title(Config::get('ripple.PROCESS_NAMES.MONITOR', 'laravel-ware'));
         repeat(static function () {
             gc_collect_cycles();
         }, 1);

--- a/src/Inspector/Client.php
+++ b/src/Inspector/Client.php
@@ -157,6 +157,7 @@ class Client
                 'RIP_HTTP_WORKERS' => Config::get('ripple.HTTP_WORKERS'),
                 'RIP_WATCH' => Config::get('ripple.WATCH'),
                 'RIP_HOOK' => InstalledVersions::isInstalled('laravel/octane') ? 0 : 1,
+                'RIP_SHELL_PROCESS_NAME' => Config::get('ripple.PROCESS_NAMES.SERVER_BIN', ''),
             ];
 
             foreach ($envs as $name => $env) {

--- a/src/Inspector/ServerBin.php
+++ b/src/Inspector/ServerBin.php
@@ -52,7 +52,7 @@ use function base_path;
 
 use const SIGTERM;
 
-cli_set_process_title('laravel-virtual');
+// Process title will be set after config is loaded
 
 define("RIP_PROJECT_PATH", realpath(getenv('RIP_PROJECT_PATH')));
 
@@ -180,6 +180,10 @@ try {
 /*** Register a singleton of Ripple service */
 $application->singleton(Manager::class, static fn () => $manager);
 $application->singleton(HttpWorker::class, static fn () => $httpWorker);
+
+/*** Set custom process title */
+$processName = $application->make('config')->get('ripple.PROCESS_NAMES.VIRTUAL', 'laravel-virtual');
+cli_set_process_title($processName);
 
 /*** Hot reload part */
 $includedFiles            = get_included_files();

--- a/src/Inspector/ServerBin.php
+++ b/src/Inspector/ServerBin.php
@@ -52,9 +52,14 @@ use function base_path;
 
 use const SIGTERM;
 
-// Process title will be set after config is loaded
-
 define("RIP_PROJECT_PATH", realpath(getenv('RIP_PROJECT_PATH')));
+
+// Set custom shell process name if available
+if ($customName = getenv('RIP_SHELL_PROCESS_NAME')) {
+    if (function_exists('cli_set_process_title')) {
+        cli_set_process_title($customName);
+    }
+}
 
 define("RIP_HOST", strval(getenv('RIP_HOST')));
 define("RIP_PORT", intval(getenv('RIP_PORT')));


### PR DESCRIPTION
Allow customization of Ripple process names to improve operational monitoring and management.

The existing process titles were hardcoded, making it difficult to distinguish between different Ripple instances or environments when monitoring processes. This change introduces configuration options via `config/ripple.php` or environment variables to set custom names for the monitor, virtual server, and HTTP worker processes, enhancing clarity for DevOps and troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-93657f28-c75c-4978-987c-6f07214581e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93657f28-c75c-4978-987c-6f07214581e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

